### PR TITLE
BUILD_REQUIRES -> TEST_REQUIRES

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,7 +27,7 @@ my %config = (
         'Storable'              => 2.39,
         'Try::Tiny'             => 0.18,
         },
-    BUILD_REQUIRES              => {
+    TEST_REQUIRES               => {
         'Test::Deep'            => 0.109,
         'Test::Exception'       => 0.31,
         'Test::NoWarnings'      => 1.04,


### PR DESCRIPTION
This commit enables me to install Redis::JobQueue, skipping tests, without installing the optional test dependencies.

The problem for me is Test::RedisServer, which tries to install Moose into my project.
