### PR TITLE
fix tests when Test::RedisServer is not installed

### DIFF
--- a/t/01_JobQueue/01_new.t
+++ b/t/01_JobQueue/01_new.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER
@@ -171,3 +172,4 @@ dies_ok { $jq = Redis::JobQueue->new(
     ) } "expecting to die";
 
 };
+

--- a/t/01_JobQueue/02_add_job.t
+++ b/t/01_JobQueue/02_add_job.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/04_load_job.t
+++ b/t/01_JobQueue/04_load_job.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/05_get_next_job.t
+++ b/t/01_JobQueue/05_get_next_job.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/06_update_job.t
+++ b/t/01_JobQueue/06_update_job.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/07_delete_job.t
+++ b/t/01_JobQueue/07_delete_job.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/08_get_job_ids.t
+++ b/t/01_JobQueue/08_get_job_ids.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use List::Util qw(
     shuffle

--- a/t/01_JobQueue/09_quit.t
+++ b/t/01_JobQueue/09_quit.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/10_max_datasize.t
+++ b/t/01_JobQueue/10_max_datasize.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/11_last_errorcode.t
+++ b/t/01_JobQueue/11_last_errorcode.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/12_timeout.t
+++ b/t/01_JobQueue/12_timeout.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Redis::JobQueue qw(
     DEFAULT_SERVER

--- a/t/01_JobQueue/13_get_job_meta_fields.t
+++ b/t/01_JobQueue/13_get_job_meta_fields.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -29,6 +28,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use List::MoreUtils qw(
     firstidx

--- a/t/01_JobQueue/14_get_job_data.t
+++ b/t/01_JobQueue/14_get_job_data.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use List::MoreUtils qw(
     firstidx

--- a/t/01_JobQueue/15_queue_status.t
+++ b/t/01_JobQueue/15_queue_status.t
@@ -8,7 +8,6 @@ use lib 'lib', 't/tlib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -24,6 +23,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Data::Dumper;
 $Data::Dumper::Sortkeys = 1;

--- a/t/01_JobQueue/16_utf8.t
+++ b/t/01_JobQueue/16_utf8.t
@@ -12,7 +12,6 @@ use lib 'lib';
 
 use Test::More;
 plan "no_plan";
-use Test::NoWarnings;
 
 BEGIN {
     eval "use Test::Exception";                 ## no critic
@@ -33,6 +32,8 @@ BEGIN {
     eval "use Net::EmptyPort";                  ## no critic
     plan skip_all => "because Net::EmptyPort required for testing" if $@;
 }
+
+use Test::NoWarnings;
 
 use Data::Dumper;
 $Data::Dumper::Sortkeys = 1;


### PR DESCRIPTION
problem: using Test::NoWarnings results in test failure if the guard for Test::RedisServer existence fails.  this results in 'Tests were run but no plan was declared and done_testing() was not seen.' which is obviously not the intent since the guard is intended to skip the test when Test::RedisServer isn't installed.

solution: move Test::NoWarnings to after the prerequisite checks